### PR TITLE
proper `style.css` reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Grace Meilen</title>
-  <link href="styles.css" media="screen" rel="stylesheet" type="text/css"/>
+  <link href="/style.css" media="screen" rel="stylesheet" type="text/css"/>
 </head>
 <body>
 


### PR DESCRIPTION
You are pointing to `styles.css` which does not exist. This does two things:

1. Now points to `style.css`; and
2. Sets the absolute URL, so you're always pointing to `site.name/style.css` versus `site.name/maybe/broken/URL/style.css`